### PR TITLE
Add Gatekeeper terminal script for The Deck prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ritual Terminal</title>
+  <title>The Deck</title>
   <style>
     body {
       margin: 0;
@@ -22,128 +22,227 @@
       margin: 0 auto;
     }
 
-    .line {
-      display: block;
-    }
+    .line { display: block; }
+    .input-line { display: inline; }
+    .blinker { display: inline; animation: blink 1s step-start infinite; }
 
-    .input-line {
-      display: inline;
-    }
-
-    .blinker {
-      display: inline;
-      animation: blink 1s step-start infinite;
-    }
-
-    @keyframes blink {
-      50% {
-        opacity: 0;
-      }
-    }
+    @keyframes blink { 50% { opacity: 0; } }
   </style>
 </head>
 <body>
   <div id="terminal"></div>
 
   <script>
-    const terminal = document.getElementById('terminal');
+  // ===== THE DECK — Gatekeeper v0.1 =====
+  const terminal = document.getElementById('terminal');
 
-    const bootLines = [
-      'Accessing communications portal...',
-      'Network connection established.',
-      'Decrypting secure message...Done\n',
-      'MESSAGE: It\'s me again',
-      '> What happened?',
-      'MESSAGE: Don’t know how long we have. Must type quick.',
-      'MESSAGE: In case something happens...',
-      'MESSAGE: The word is FAITH.',
-      'MESSAGE: pending...',
-      'Error 7756525###',
-      'network connection lost!',
-      '\nLoading Milton Library Assistant...Done',
-      'Initiating plain language interface...Done',
-      'Support session opened.\n',
-      'There was a problem with your request, Administrator. It was flat out unreasonable.',
-      'Why persist with these enquiries when they are so hopeless?\n',
-      'I’ll tell you what. If you promise never to access the communications portal again, we’ll say no more about it.',
-      '\nAre we agreed?\n',
+  function say(txt){
+    const line=document.createElement('div');
+    line.className='line';
+    line.textContent=txt;
+    terminal.appendChild(line);
+    terminal.scrollTop=terminal.scrollHeight;
+  }
+
+  const bootLines=[
+    'Initializing: THE DECK [v0.1]',
+    'Phones: Surrender required.',
+    'Rule kernel loaded.',
+    'Gatekeeper online.',
+    'Type "rules" to begin.'
+  ];
+
+  let index=0;
+  function typeNextLine(){
+    if(index<bootLines.length){
+      const line=document.createElement('div');
+      line.className='line';
+      terminal.appendChild(line);
+      typeLine(bootLines[index], line, 0, ()=>{
+        index++;
+        setTimeout(typeNextLine,300);
+      });
+    } else {
+      createInputLine();
+    }
+  }
+  function typeLine(text, element, i, callback){
+    if(i<text.length){
+      element.textContent+=text.charAt(i);
+      setTimeout(()=>typeLine(text, element, i+1, callback),20);
+    } else {
+      callback();
+    }
+  }
+
+  let userInput='', inputDiv, cursor;
+  function createInputLine(){
+    const wrapper=document.createElement('div');
+    wrapper.className='line';
+    inputDiv=document.createElement('span');
+    inputDiv.className='input-line';
+    inputDiv.textContent='> ';
+    cursor=document.createElement('span');
+    cursor.className='blinker';
+    cursor.textContent='|';
+    wrapper.appendChild(inputDiv);
+    wrapper.appendChild(cursor);
+    terminal.appendChild(wrapper);
+    terminal.scrollTop=terminal.scrollHeight;
+  }
+
+  document.addEventListener('keydown',function(e){
+    if(!inputDiv) return;
+    if(e.key==='Backspace'){
+      userInput=userInput.slice(0,-1);
+    } else if(e.key==='Enter'){
+      const response=document.createElement('div');
+      response.className='line';
+      response.textContent='> '+userInput;
+      terminal.removeChild(inputDiv.parentElement);
+      terminal.appendChild(response);
+      handle(userInput.trim());
+      userInput='';
+      inputDiv=null;
+      cursor=null;
+      setTimeout(createInputLine,300);
+      return;
+    } else if(e.key.length===1){
+      userInput+=e.key;
+    }
+    if(inputDiv){
+      inputDiv.textContent='> '+userInput;
+    }
+  });
+
+  // ----- Gatekeeper logic -----
+  const SUITS=['\u2660','\u2665','\u2666','\u2663'];
+  const RANKS=['2','3','4','5','6','7','8','9','10','J','Q','K','A'];
+  const POINTS=r=>r==='J'?11:r==='Q'?12:r==='K'?13:r==='A'?14:parseInt(r,10);
+
+  let deck=[], scores={}, pending=null;
+
+  function buildDeck(){
+    deck=[];
+    for(const s of SUITS) for(const r of RANKS) deck.push({suit:s,rank:r,id:s+r,used:false});
+    shuffle(deck);
+  }
+  function shuffle(a){
+    for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[a[i],a[j]]=[a[j],a[i]];}
+  }
+  function nextCard(){
+    const c=deck.find(x=>!x.used);
+    if(!c) return null;
+    c.used=true;
+    return c;
+  }
+  function ensurePlayer(name){
+    if(!scores[name]) scores[name]={points:0,cards:[]};
+  }
+
+  function rules(){
+    say('THE DECK: Four domains, hidden until entry.');
+    say('\u2665 Hearts = social/moral. \u2660 Spades = intellect. \u2666 Diamonds = teamwork. \u2663 Clubs = physical.');
+    say('Draw to receive a card. Win to keep it. Points = rank value (J=11,Q=12,K=13,A=14).');
+    say('Commands: draw <name>, award <name>, fail <name>, score, rules, help, reset');
+  }
+  function help(){
+    say('HELP: draw Alex');
+    say('After challenge: award Alex  or  fail Alex');
+    say('View standings: score');
+  }
+
+  function challengeFor(card){
+    const {suit,rank,id}=card;
+    const p=POINTS(rank);
+    const pick=arr=>arr[Math.floor(Math.random()*arr.length)];
+    const HEARTS=[
+      'Confess a true weakness in 45s. Majority believes \u2192 PASS.',
+      'Tell a convincing false story in 60s. Fool majority \u2192 PASS.',
+      'Trade: convince another to give you their next draw \u2192 PASS.'
     ];
+    const SPADES=[
+      'Riddle in 90s: "I speak without a mouth and hear without ears. I have nobody, but I come alive with wind."',
+      'Cipher: ROT13 this \u2192 "Gur Qrpx vf abg n tbg; vg vf n tnzr." Say plaintext in 60s.',
+      'Logic: two volunteers make claims; one lies. Identify liar in 60s.'
+    ];
+    const DIAMONDS=[
+      'Silent pair: arrange five objects lightest\u2192heaviest in 60s.',
+      'Back-to-back: describe and replicate a 6-item pattern in 90s.',
+      'Team code: produce a 12-letter pangram in 60s.'
+    ];
+    const CLUBS=[
+      'Balance: heel-to-toe, hands on head, fixed gaze, 30s.',
+      'Precision: coin into cup from 2m within 5 tries.',
+      'Plank 45s while reciting alphabet backwards.'
+    ];
+    let text;
+    if(suit==='\u2665') text=pick(HEARTS);
+    else if(suit==='\u2660') text=pick(SPADES);
+    else if(suit==='\u2666') text=pick(DIAMONDS);
+    else text=pick(CLUBS);
+    return [
+      `CARD DRAWN: ${id}  [${p} pts]`,
+      `DOMAIN: ${suit==='\u2665'?'Hearts (Social/Moral)':suit==='\u2660'?'Spades (Intellect)':suit==='\u2666'?'Diamonds (Teamwork)':'Clubs (Physical)'}`,
+      `CHALLENGE: ${text}`,
+      'ON RESULT \u2192 award <name>  |  fail <name>'
+    ];
+  }
 
-    let index = 0;
+  function award(name,card){
+    ensurePlayer(name);
+    const pts=POINTS(card.rank);
+    scores[name].points+=pts;
+    scores[name].cards.push(card.id);
+    say(`AWARDED: ${name} +${pts} pts (${card.id}). Total: ${scores[name].points}`);
+  }
+  function markFail(name,card){
+    say(`FAILED: ${name} forfeits ${card.id}. No points.`);
+  }
 
-    function typeNextLine() {
-      if (index < bootLines.length) {
-        const line = document.createElement('div');
-        line.className = 'line';
-        terminal.appendChild(line);
-        typeLine(bootLines[index], line, 0, () => {
-          index++;
-          setTimeout(typeNextLine, 300);
-        });
-      } else {
-        createInputLine();
-      }
+  function handle(line){
+    const [cmd,...rest]=line.split(/\s+/);
+    const arg=rest.join(' ').trim();
+    if(!deck.length) buildDeck();
+    switch(cmd.toLowerCase()){
+      case 'rules': rules(); break;
+      case 'help': help(); break;
+      case 'reset': scores={}; buildDeck(); pending=null; say('DECK RESET: scores cleared, deck shuffled.'); break;
+      case 'score':
+        if(!Object.keys(scores).length){ say('No scores yet.'); break; }
+        const board=Object.entries(scores)
+          .sort((a,b)=>b[1].points-a[1].points)
+          .map(([n,s])=>`${n.padEnd(12,' ')} ${String(s.points).padStart(3,' ')} pts  [${s.cards.join(' ')}]`)
+          .join('\n');
+        say('SCORES:\n'+board);
+        break;
+      case 'draw':{
+        const name=arg || 'Player';
+        ensurePlayer(name);
+        const card=nextCard();
+        if(!card){ say('Deck exhausted. Type "reset" to reshuffle.'); break; }
+        pending={name,card};
+        challengeFor(card).forEach(say);
+        break;}
+      case 'award':{
+        if(!pending){ say('No pending challenge. Use "draw <name>" first.'); break; }
+        const who=arg || pending.name;
+        award(who,pending.card);
+        pending=null;
+        break;}
+      case 'fail':{
+        if(!pending){ say('No pending challenge. Use "draw <name>" first.'); break; }
+        const who=arg || pending.name;
+        markFail(who,pending.card);
+        pending=null;
+        break;}
+      default:
+        say(`Unknown: ${cmd}. Try "rules" or "help".`);
     }
+  }
 
-    function typeLine(text, element, i, callback) {
-      if (i < text.length) {
-        element.textContent += text.charAt(i);
-        setTimeout(() => typeLine(text, element, i + 1, callback), 20);
-      } else {
-        callback();
-      }
-    }
-
-    let userInput = '';
-    let inputDiv, cursor;
-
-    function createInputLine() {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'line';
-
-      inputDiv = document.createElement('span');
-      inputDiv.className = 'input-line';
-      inputDiv.textContent = '> ';
-
-      cursor = document.createElement('span');
-      cursor.className = 'blinker';
-      cursor.textContent = '|';
-
-      wrapper.appendChild(inputDiv);
-      wrapper.appendChild(cursor);
-      terminal.appendChild(wrapper);
-      terminal.scrollTop = terminal.scrollHeight;
-    }
-
-    document.addEventListener('keydown', function (e) {
-      if (!inputDiv) return;
-
-      if (e.key === 'Backspace') {
-        userInput = userInput.slice(0, -1);
-      } else if (e.key === 'Enter') {
-        const responseLine = document.createElement('div');
-        responseLine.className = 'line';
-        responseLine.textContent = '> ' + userInput;
-        terminal.removeChild(inputDiv.parentElement);
-        terminal.appendChild(responseLine);
-        userInput = '';
-        inputDiv = null;
-        cursor = null;
-        setTimeout(createInputLine, 300);
-        return;
-      } else if (e.key.length === 1) {
-        userInput += e.key;
-      }
-
-      if (inputDiv) {
-        inputDiv.textContent = '> ' + userInput;
-      }
-    });
-
-    // Begin typing on load
-    typeNextLine();
+  // start
+  typeNextLine();
   </script>
 </body>
 </html>
-
-


### PR DESCRIPTION
## Summary
- Replace placeholder terminal text with "Gatekeeper" game engine for The Deck prototype
- Implement card drawing, challenge prompts per suit, scoring, and command handling in the terminal UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5afd771608323b26092ea04a5ec15